### PR TITLE
add YARA detection for compromised cert serial

### DIFF
--- a/rules/SUNBURST/yara/solarwinds_compromised_cert.yara
+++ b/rules/SUNBURST/yara/solarwinds_compromised_cert.yara
@@ -1,0 +1,10 @@
+rule solarwinds_sunburst_compromised_cert
+{
+meta:
+    description = "Detects signing certificate serial used in trojanized SolarWinds .msp hotfix"
+    hash = "d0d626deb3f9484e649294a8dfa814c5568f846d5aa02d4cdad5d041a29d5600"
+strings:
+    $ = {0F E9 73 75 20 22 A6 06 AD F2 A3 6E 34 5D C0 ED}
+condition:
+    any of them
+}


### PR DESCRIPTION
the signing certificate should be considered compromised 

this rule detects the cert serial number in a binary

![image](https://user-images.githubusercontent.com/5124946/102143009-49f45100-3e31-11eb-9519-10bbee1e6e49.png)

https://www.virustotal.com/gui/file/d0d626deb3f9484e649294a8dfa814c5568f846d5aa02d4cdad5d041a29d5600/details 