### PR TITLE
Remove COSMICGALE and SUPERNOVA rules

### DIFF
--- a/all-yara.yar
+++ b/all-yara.yar
@@ -69,37 +69,6 @@ rule APT_Backdoor_SUNBURST_2
     condition:
         ($a and $b and $c and $d and $e and $f and $h and $i) or ($j and $k and $l and $m and $n and $o and $p and $q and $r and $s and ($aa or $ab)) or ($t and $u and $v and $w and $x and $y and $z and ($aa or $ab)) or ($ac and $ad and $ae and $af and $ag and $ah and ($am or $an)) or ($ai and $aj and $ak and $al and ($am or $an))
 }
-rule APT_Webshell_SUPERNOVA_1
-{
-    meta:
-        author = "FireEye"
-        description = "SUPERNOVA is a .NET web shell backdoor masquerading as a legitimate SolarWinds web service handler. SUPERNOVA inspects and responds to HTTP requests with the appropriate HTTP query strings, Cookies, and/or HTML form values (e.g. named codes, class, method, and args). This rule is looking for specific strings and attributes related to SUPERNOVA."
-    strings:
-        $compile1 = "CompileAssemblyFromSource"
-        $compile2 = "CreateCompiler"
-        $context = "ProcessRequest"
-        $httpmodule = "IHttpHandler" ascii
-        $string1 = "clazz"
-        $string2 = "//NetPerfMon//images//NoLogo.gif" wide
-        $string3 = "SolarWinds" ascii nocase wide
-    condition:
-        uint16(0) == 0x5a4d and uint32(uint32(0x3C)) == 0x00004550 and filesize < 10KB and pe.imports("mscoree.dll","_CorDllMain") and $httpmodule and $context and all of ($compile*) and all of ($string*)
-}
-rule APT_Webshell_SUPERNOVA_2
-{
-    meta:
-        author = "FireEye"
-        description = "This rule is looking for specific strings related to SUPERNOVA. SUPERNOVA is a .NET web shell backdoor masquerading as a legitimate SolarWinds web service handler. SUPERNOVA inspects and responds to HTTP requests with the appropriate HTTP query strings, Cookies, and/or HTML form values (e.g. named codes, class, method, and args)."
-    strings:
-        $dynamic = "DynamicRun"
-        $solar = "Solarwinds" nocase
-        $string1 = "codes"
-        $string2 = "clazz"
-        $string3 = "method"
-        $string4 = "args"
-    condition:
-        uint16(0) == 0x5a4d and uint32(uint32(0x3C)) == 0x00004550 and filesize < 10KB and 3 of ($string*) and $dynamic and $solar
-}
 rule APT_Dropper_Raw64_TEARDROP_1
 {
     meta:

--- a/all-yara.yar
+++ b/all-yara.yar
@@ -100,24 +100,6 @@ rule APT_Webshell_SUPERNOVA_2
     condition:
         uint16(0) == 0x5a4d and uint32(uint32(0x3C)) == 0x00004550 and filesize < 10KB and 3 of ($string*) and $dynamic and $solar
 }
-rule APT_HackTool_PS1_COSMICGALE_1
-{
-    meta:
-        author = "FireEye"
-        description = "This rule detects various unique strings related to COSMICGALE. COSMICGALE is a credential theft and reconnaissance PowerShell script that collects credentials using the publicly available Get-PassHashes routine. COSMICGALE clears log files, writes acquired data to a hard coded path, and encrypts the file with a password."
-    strings:
-        $sr1 = /\[byte\[\]\]@\([\x09\x20]{0,32}0xaa[\x09\x20]{0,32},[\x09\x20]{0,32}0xd3[\x09\x20]{0,32},[\x09\x20]{0,32}0xb4[\x09\x20]{0,32},[\x09\x20]{0,32}0x35[\x09\x20]{0,32},/ ascii nocase wide
-        $sr2 = /\[bitconverter\]::toint32\(\$\w{1,64}\[0x0c..0x0f\][\x09\x20]{0,32},[\x09\x20]{0,32}0\)[\x09\x20]{0,32}\+[\x09\x20]{0,32}0xcc\x3b/ ascii nocase wide
-        $sr3 = /\[byte\[\]\]\(\$\w{1,64}\.padright\(\d{1,2}\)\.substring\([\x09\x20]{0,32}0[\x09\x20]{0,32},[\x09\x20]{0,32}\d{1,2}\)\.tochararray\(\)\)/ ascii nocase wide
-        $ss1 = "[text.encoding]::ascii.getbytes(\"ntpassword\x600\");" ascii nocase wide
-        $ss2 = "system\\currentcontrolset\\control\\lsa\\$_" ascii nocase wide
-        $ss3 = "[security.cryptography.md5]::create()" ascii nocase wide
-        $ss4 = "[system.security.principal.windowsidentity]::getcurrent().name" ascii nocase wide
-        $ss5 = "out-file" ascii nocase wide
-        $ss6 = "convertto-securestring" ascii nocase wide
-    condition:
-        all of them
-}
 rule APT_Dropper_Raw64_TEARDROP_1
 {
     meta:


### PR DESCRIPTION
Please consider removing this Yara rule from the repo to reduce on-going industry confusion. Based on my analysis, shared with FEYE pre-publication on 2020-12-10, this unsigned SolarWinds "plugin"/webshell DLL (SUPERNOVA) may be abused maliciously - but that post-exploitation activity and filewrites occur within inetpub in-the-wild and are more indicative of web-facing exploitation with artifacts more similar to CVE-2019-8917. One of the post-compromise scripts run is what is labeled as COSMICGALE.

As there is no tied to the software supply chain compromises, we are not currently tracking this as the same threat actor - and my understanding is that FireEye is also no longer tracking this as UNC2452. Since COSMICGALE and SUPERNOVA are not referenced in the blog with this delineation, it's probably better to remove for now (or add clarification if there's a linkage).

-YOUR BOY CARR